### PR TITLE
Option set and Two options Enums

### DIFF
--- a/AlbanianXrm.Common.Shared/Constants.cs
+++ b/AlbanianXrm.Common.Shared/Constants.cs
@@ -15,5 +15,11 @@
         public const string ENVIRONMENT_REMOVEPROPERTYCHANGED = "AlbanianXrm.EarlyBound:RemovePropertyChanged";
         public const string ENVIRONMENT_ATTACHDEBUGGER = "AlbanianXrm.EarlyBound:AttachDebugger";
         public const string ENVIRONMENT_CACHEMEATADATA = "AlbanianXrm.EarlyBound:CacheMetadata";
+        public const string ENVIRONMENT_OPTIONSETENUMS = "AlbanianXrm.EarlyBound:OptionSetEnums";
+        public const string ENVIRONMENT_TWOOPTIONS = "AlbanianXrm.EarlyBound:TwoOptions";
+        public const string ENVIRONMENT_OPTIONSETENUMPROPERTIES = "AlbanianXrm.EarlyBound:OptionSetEnumProperties";      
+
+        public const string EntityLogicalNameAttributeType = "Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute";
+        public const string AttributeLogicalNameAttributeType = "Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute";
     }
 }

--- a/AlbanianXrm.CrmSvcUtilExtensions/AlbanianXrm.CrmSvcUtilExtensions.csproj
+++ b/AlbanianXrm.CrmSvcUtilExtensions/AlbanianXrm.CrmSvcUtilExtensions.csproj
@@ -80,6 +80,7 @@
   <ItemGroup>
     <Compile Include="CustomizationService.cs" />
     <Compile Include="EnumItem.cs" />
+    <Compile Include="Extensions\CollectionExtensions.cs" />
     <Compile Include="FilteringService.cs" />
     <Compile Include="MetadataService.cs" />
     <Compile Include="OptionSetEnumHandler.cs" />

--- a/AlbanianXrm.CrmSvcUtilExtensions/AlbanianXrm.CrmSvcUtilExtensions.csproj
+++ b/AlbanianXrm.CrmSvcUtilExtensions/AlbanianXrm.CrmSvcUtilExtensions.csproj
@@ -79,8 +79,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CustomizationService.cs" />
+    <Compile Include="EnumItem.cs" />
     <Compile Include="FilteringService.cs" />
     <Compile Include="MetadataService.cs" />
+    <Compile Include="OptionSetEnumHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AlbanianXrm.CrmSvcUtilExtensions/CustomizationService.cs
+++ b/AlbanianXrm.CrmSvcUtilExtensions/CustomizationService.cs
@@ -1,12 +1,6 @@
-﻿using AlbanianXrm.Extensions;
-using Microsoft.Crm.Services.Utility;
-using Microsoft.Xrm.Sdk.Metadata;
+﻿using Microsoft.Crm.Services.Utility;
 using System;
 using System.CodeDom;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace AlbanianXrm.CrmSvcUtilExtensions
 {
@@ -25,13 +19,14 @@ namespace AlbanianXrm.CrmSvcUtilExtensions
 
         public void CustomizeCodeDom(CodeCompileUnit codeUnit, IServiceProvider services)
         {
-            var optionSetEnumHandler = new OptionSetEnumHandler(codeUnit, services);
+            var removePropertyChanged = (Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_REMOVEPROPERTYCHANGED) ?? "") != "";
+            var optionSetEnumHandler = new OptionSetEnumHandler(codeUnit, services,removePropertyChanged);
             optionSetEnumHandler.FixStateCode();
             if ((Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_OPTIONSETENUMS) ?? "") != "")
             {
                 optionSetEnumHandler.GenerateOptionSets();
             }
-            var removePropertyChanged = (Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_REMOVEPROPERTYCHANGED) ?? "") != "";
+          
             if (removePropertyChanged)
             {
                 for (var i = 0; i < codeUnit.Namespaces.Count; i++)

--- a/AlbanianXrm.CrmSvcUtilExtensions/CustomizationService.cs
+++ b/AlbanianXrm.CrmSvcUtilExtensions/CustomizationService.cs
@@ -1,6 +1,9 @@
-﻿using Microsoft.Crm.Services.Utility;
+﻿using AlbanianXrm.Extensions;
+using Microsoft.Crm.Services.Utility;
 using System;
 using System.CodeDom;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace AlbanianXrm.CrmSvcUtilExtensions
 {
@@ -15,10 +18,22 @@ namespace AlbanianXrm.CrmSvcUtilExtensions
                 System.Diagnostics.Debugger.Launch();
             }
 #endif
+            entities = new HashSet<string>((Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_ENTITIES) ?? "").Split(","));
+            allAttributes = new HashSet<string>((Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_ALL_ATTRIBUTES) ?? "").Split(","));
+            entityAttributes = new Dictionary<string, HashSet<string>>();
+            foreach (var entity in entities.Except(allAttributes))
+            {
+                entityAttributes.Add(entity, new HashSet<string>((Environment.GetEnvironmentVariable(string.Format(Constants.ENVIRONMENT_ENTITY_ATTRIBUTES, entity)) ?? "").Split(",")));
+            }
         }
+
+        private HashSet<string> entities;
+        private HashSet<string> allAttributes;
+        private Dictionary<string, HashSet<string>> entityAttributes;
 
         public void CustomizeCodeDom(CodeCompileUnit codeUnit, IServiceProvider services)
         {
+            FixStateCode(codeUnit);
             var removePropertyChanged = (Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_REMOVEPROPERTYCHANGED) ?? "") != "";
             if (removePropertyChanged)
             {
@@ -77,6 +92,80 @@ namespace AlbanianXrm.CrmSvcUtilExtensions
                     }
                 }
             }
+        }
+
+        private void FixStateCode(CodeCompileUnit codeUnit)
+        {
+            foreach (CodeNamespace @namespace in codeUnit.Namespaces)
+            {
+                for (int i = 0; i < @namespace.Types.Count; i++)
+                {
+                    var thisType = @namespace.Types[i];
+                    if (!thisType.IsClass) continue;
+                    var entity = GetEntityLogicalName(thisType);
+                    if (entity == null || allAttributes.Contains(entity)) continue;
+                    if (entityAttributes.TryGetValue(entity, out HashSet<string> attributes) &&
+                        !attributes.Contains("statecode"))
+                    {
+                        for (int j = 0; j < thisType.Members.Count; j++)
+                        {
+                            if (thisType.Members[j] is CodeMemberProperty property)
+                            {
+                                var attribute = GetAttributeLogicalName(property);
+                                if (attribute != "statecode") continue;                               
+                                RemoveClass(codeUnit, property.Type.TypeArguments[0].BaseType); 
+                                thisType.Members.Remove(property);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private void RemoveClass(CodeCompileUnit codeUnit, string baseType)
+        {
+            foreach (CodeNamespace @namespace in codeUnit.Namespaces)
+            {
+                foreach (CodeTypeDeclaration type in @namespace.Types)
+                {
+                    if ($"{@namespace.Name}.{type.Name}"==baseType)
+                    {
+                        @namespace.Types.Remove(type);
+                        return;
+                    }
+                }
+            }
+        }
+
+        private string GetEntityLogicalName(CodeTypeDeclaration type)
+        {
+            foreach (CodeAttributeDeclaration attribute in type.CustomAttributes)
+            {
+                if (attribute.Name == "Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute")
+                {
+                    if (attribute.Arguments[0].Value is CodePrimitiveExpression value)
+                    {
+                        return (string)value.Value;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private string GetAttributeLogicalName(CodeTypeMember member)
+        {
+            foreach (CodeAttributeDeclaration attribute in member.CustomAttributes)
+            {
+                if (attribute.Name == "Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute")
+                {
+                    if (attribute.Arguments[0].Value is CodePrimitiveExpression value)
+                    {
+                        return (string)value.Value;
+                    }
+                }
+            }
+            return null;
         }
     }
 }

--- a/AlbanianXrm.CrmSvcUtilExtensions/EnumItem.cs
+++ b/AlbanianXrm.CrmSvcUtilExtensions/EnumItem.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.Xrm.Sdk.Metadata;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AlbanianXrm.CrmSvcUtilExtensions
+{
+    /// <remarks>
+    /// Most of the code in this class is taken from https://github.com/mjfpalmer/CRMSvcUtilGenerateOptionSetEnums
+    /// </remarks>
+    internal class EnumItem
+    {
+        public EnumItem(int key, string value, string description)
+        {
+            this.Key = key;
+            this.Value = ToValidIdentifier(value);
+            this.Description = description;
+        }
+
+        public int Key { get; }
+
+        public string Value { get; private set; }
+
+        public string Description { get; }
+
+        internal static IEnumerable<EnumItem> ToUniqueValues(OptionMetadataCollection optionMetadataCollection)
+        {
+            return ToUniqueValues(optionMetadataCollection.Select(omc => new EnumItem(omc.Value.Value, omc.Label.UserLocalizedLabel.Label, omc.Label.UserLocalizedLabel.Label)).ToList());
+        }
+
+        internal static IEnumerable<EnumItem> ToUniqueValues(BooleanOptionSetMetadata booleanOptionSetMetadata)
+        {
+            List<EnumItem> values = new List<EnumItem>();
+            if (booleanOptionSetMetadata.FalseOption == null)
+            {
+                values.Add(new EnumItem(0, "No", "No"));
+            }
+            else
+            {
+                values.Add(new EnumItem(booleanOptionSetMetadata.FalseOption.Value.Value, booleanOptionSetMetadata.FalseOption.Label.UserLocalizedLabel.Label, booleanOptionSetMetadata.FalseOption.Label.UserLocalizedLabel.Label));
+            }
+
+            if (booleanOptionSetMetadata.TrueOption == null)
+            {
+                values.Add(new EnumItem(1, "Yes", "Yes"));
+            }
+            else
+            {
+                values.Add(new EnumItem(booleanOptionSetMetadata.TrueOption.Value.Value, booleanOptionSetMetadata.TrueOption.Label.UserLocalizedLabel.Label, booleanOptionSetMetadata.TrueOption.Label.UserLocalizedLabel.Label));
+            }
+            return ToUniqueValues(values);
+        }
+
+
+        private static IEnumerable<EnumItem> ToUniqueValues(IEnumerable<EnumItem> source)
+        {
+            Dictionary<string, int> uniqueValues = source.GroupBy(sv => sv.Value).ToDictionary(g => g.Key, g => g.Count());
+            source.ToList().ForEach(sv => sv.Value = uniqueValues[sv.Value] == 1 ? sv.Value : string.Format("{0}_{1}", sv.Value, sv.Key.ToString(CultureInfo.InvariantCulture)));
+            return source;
+        }
+
+        private static string ToValidIdentifier(string source)
+        {
+            string result = string.Empty;
+
+            source = ReplaceSpecial(source ?? string.Empty);
+
+            foreach (Match m in Regex.Matches(source, "[A-Za-z0-9]"))
+            {
+                result += m.ToString();
+            }
+
+            if (string.IsNullOrEmpty(source))
+            {
+                result = "None";
+            }
+
+            if (char.IsDigit(result[0]))
+            {
+                result = "_" + result;
+            }
+
+            return result;
+        }
+
+        private static string ReplaceSpecial(string value)
+        {
+            return value.Replace("<>", "NotEquals").Replace("!=", "NotEquals").Replace("=", "Equals").Replace("<", "LessThan").Replace(">", "GreaterThan").Replace("+", "Plus");
+        }
+    }
+}

--- a/AlbanianXrm.CrmSvcUtilExtensions/Extensions/CollectionExtensions.cs
+++ b/AlbanianXrm.CrmSvcUtilExtensions/Extensions/CollectionExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System.CodeDom;
+using System.Collections.Generic;
+
+namespace AlbanianXrm.CrmSvcUtilExtensions.Extensions
+{
+    public static class CollectionExtensions
+    {
+        public static IEnumerable<CodeTypeDeclaration> ToEnumerable(this CodeTypeDeclarationCollection collection)
+        {
+            foreach (CodeTypeDeclaration codeTypeDeclaration in collection)
+            {
+                yield return codeTypeDeclaration;
+            }
+        }
+
+        public static IEnumerable<CodeTypeMember> ToEnumerable(this CodeTypeMemberCollection collection)
+        {
+            foreach (CodeTypeMember codeTypeMember in collection)
+            {
+                yield return codeTypeMember;
+            }
+        }
+
+        public static IEnumerable<T> ToEnumerable<T>(this CodeTypeMemberCollection collection) where T : CodeTypeMember
+        {
+            foreach (CodeTypeMember codeTypeMember in collection)
+            {
+                if (codeTypeMember is T tMember)
+                {
+                    yield return tMember;
+                }
+            }
+        }
+    }
+}

--- a/AlbanianXrm.CrmSvcUtilExtensions/OptionSetEnumHandler.cs
+++ b/AlbanianXrm.CrmSvcUtilExtensions/OptionSetEnumHandler.cs
@@ -1,0 +1,292 @@
+﻿using AlbanianXrm.Extensions;
+using Microsoft.Crm.Services.Utility;
+using Microsoft.Xrm.Sdk.Metadata;
+using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace AlbanianXrm.CrmSvcUtilExtensions
+{
+    internal class OptionSetEnumHandler
+    {
+        CodeCompileUnit codeUnit;
+        private HashSet<string> entities;
+        private HashSet<string> allAttributes;
+        private Dictionary<string, HashSet<string>> entityAttributes;
+        private IServiceProvider services;
+        private IOrganizationMetadata organizationMetadata;
+        private readonly bool TwoOptionsEnum;
+        private readonly bool TwoOptionsConstants;
+        private readonly bool OptionSetEnumProperties;
+        private string CrmSvcUtilsVersion;
+        private string CrmSvcUtilsName;
+
+        public OptionSetEnumHandler(CodeCompileUnit codeUnit, IServiceProvider services)
+        {
+            this.codeUnit = codeUnit;
+            this.services = services;
+            entities = new HashSet<string>((Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_ENTITIES) ?? "").Split(","));
+            allAttributes = new HashSet<string>((Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_ALL_ATTRIBUTES) ?? "").Split(","));
+            entityAttributes = new Dictionary<string, HashSet<string>>();
+            foreach (var entity in entities.Except(allAttributes))
+            {
+                entityAttributes.Add(entity, new HashSet<string>((Environment.GetEnvironmentVariable(string.Format(Constants.ENVIRONMENT_ENTITY_ATTRIBUTES, entity)) ?? "").Split(",")));
+            }
+            TwoOptionsEnum = (Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_TWOOPTIONS) ?? "") == "1";
+            TwoOptionsConstants = (Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_TWOOPTIONS) ?? "") == "2";
+            OptionSetEnumProperties = (Environment.GetEnvironmentVariable(Constants.ENVIRONMENT_OPTIONSETENUMPROPERTIES) ?? "") != "";
+            CrmSvcUtilsVersion = FileVersionInfo.GetVersionInfo(typeof(SdkMessage).Assembly.Location).FileVersion;
+            CrmSvcUtilsName = typeof(SdkMessage).Assembly.GetName().Name;
+        }
+
+        public void FixStateCode()
+        {
+            foreach (CodeNamespace @namespace in codeUnit.Namespaces)
+            {
+                for (int i = 0; i < @namespace.Types.Count; i++)
+                {
+                    var thisType = @namespace.Types[i];
+                    if (!thisType.IsClass) continue;
+                    var entity = GetEntityLogicalName(thisType);
+                    if (entity == null || allAttributes.Contains(entity)) continue;
+                    if (entityAttributes.TryGetValue(entity, out HashSet<string> attributes) &&
+                        !attributes.Contains("statecode"))
+                    {
+                        for (int j = 0; j < thisType.Members.Count; j++)
+                        {
+                            if (thisType.Members[j] is CodeMemberProperty property)
+                            {
+                                var attribute = GetAttributeLogicalName(property);
+                                if (attribute != "statecode") continue;
+                                RemoveClass(property.Type.TypeArguments[0].BaseType);
+                                thisType.Members.Remove(property);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void GenerateOptionSets()
+        {
+            var metadataProvider = (IMetadataProviderService)services.GetService(typeof(IMetadataProviderService));
+            this.organizationMetadata = metadataProvider.LoadMetadata();
+            GenerateOptionSetEnums();
+        }
+
+        private void GenerateOptionSetEnums()
+        {
+            foreach (CodeNamespace @namespace in codeUnit.Namespaces)
+            {
+                CodeTypeDeclaration globalOptionSets = null;
+                foreach (CodeTypeDeclaration type in @namespace.Types)
+                {
+                    if (type.Name == "OptionSets")
+                    {
+                        globalOptionSets = type;
+                        break;
+                    }
+                }
+                if (globalOptionSets == null)
+                {
+                    globalOptionSets = new CodeTypeDeclaration("OptionSets");
+                    globalOptionSets.Attributes = MemberAttributes.Static | MemberAttributes.Public;
+                    globalOptionSets.IsClass = true;
+                    @namespace.Types.Add(globalOptionSets);
+                }
+                foreach (CodeTypeDeclaration type in @namespace.Types)
+                {
+                    if (!type.IsClass) continue;
+                    var entity = GetEntityLogicalName(type);
+                    if (entity == null) continue;
+                    var entityMetadata = organizationMetadata.Entities.First(x => x.LogicalName == entity);
+                    CodeTypeDeclaration optionSets = null;
+                    foreach (CodeTypeMember member in type.Members)
+                    {
+                        if (member is CodeTypeDeclaration typeDeclaration)
+                        {
+                            if (typeDeclaration.Name == "OptionSets")
+                            {
+                                optionSets = typeDeclaration;
+                                break;
+                            }
+                        }
+                    }
+                    if (optionSets == null)
+                    {
+                        optionSets = new CodeTypeDeclaration("OptionSets");
+                        optionSets.Attributes = MemberAttributes.Static | MemberAttributes.Public;
+                        optionSets.IsClass = true;
+                        type.Members.Add(optionSets);
+                    }
+                    foreach (CodeTypeMember member in type.Members)
+                    {
+                        if (member is CodeMemberProperty property)
+                        {
+                            var attribute = GetAttributeLogicalName(member);
+                            if (attribute == null) continue;
+                            var attributeMetadata = entityMetadata.Attributes.FirstOrDefault(x => x.LogicalName == attribute);
+                            CodeTypeMember generatedMember = null;
+                            bool isGlobal = false;
+                            if (attributeMetadata is BooleanAttributeMetadata booleanAttribute)
+                            {
+                                if (TwoOptionsEnum)
+                                {
+                                    generatedMember = GenerateEnumTwoOptions(booleanAttribute);
+                                }
+                                if (TwoOptionsConstants)
+                                {
+                                    generatedMember = GenerateConstantTwoOptions(booleanAttribute);
+                                }
+                                isGlobal = booleanAttribute.OptionSet.IsGlobal == true;
+                            }
+                            else if (attributeMetadata is StateAttributeMetadata stateAttribute)
+                            {
+                                generatedMember = GenerateEnumOptions(attributeMetadata.SchemaName, stateAttribute.OptionSet.Options);
+                                isGlobal = stateAttribute.OptionSet.IsGlobal == true;
+                            }
+                            else if (attributeMetadata is StatusAttributeMetadata statusAttribute)
+                            {
+                                generatedMember = GenerateEnumOptions(attributeMetadata.SchemaName, statusAttribute.OptionSet.Options);
+                                isGlobal = statusAttribute.OptionSet.IsGlobal == true;
+                            }
+                            else if (attributeMetadata is PicklistAttributeMetadata picklistAttribute)
+                            {
+                                generatedMember = GenerateEnumOptions(attributeMetadata.SchemaName, picklistAttribute.OptionSet.Options);
+                                isGlobal = picklistAttribute.OptionSet.IsGlobal == true;
+                            }
+                            if (generatedMember == null) continue;
+                            if (isGlobal)
+                            {
+                                bool exists = false;
+                                foreach (CodeTypeMember globalOptionSet in globalOptionSets.Members)
+                                {
+                                    if(globalOptionSet.Name==generatedMember.Name)
+                                    {
+                                        exists = true;
+                                        break;
+                                    }
+                                }
+                                if (exists) continue;
+                                globalOptionSets.Members.Add(generatedMember);
+                            }
+                            else
+                            {
+                                optionSets.Members.Add(generatedMember);
+                            }
+                        }
+                    }
+                    if (optionSets.Members.Count == 0)
+                    {
+                        type.Members.Remove(optionSets);
+                    }
+                }
+                if (globalOptionSets.Members.Count == 0)
+                {
+                    @namespace.Types.Remove(globalOptionSets);
+                }
+            }
+        }
+
+        private CodeTypeMember GenerateEnumOptions(string schemaName, OptionMetadataCollection optionSet)
+        {
+            return GenerateEnumOptions(schemaName, EnumItem.ToUniqueValues(optionSet));
+        }
+
+        private CodeTypeMember GenerateEnumOptions(string schemaName, IEnumerable<EnumItem> values)
+        {
+            CodeTypeDeclaration optionSetEnum = new CodeTypeDeclaration(schemaName);
+            optionSetEnum.IsEnum = true;
+            optionSetEnum.CustomAttributes.Add(new CodeAttributeDeclaration("System.Runtime.Serialization.DataContractAttribute"));
+            optionSetEnum.CustomAttributes.Add(new CodeAttributeDeclaration("System.CodeDom.Compiler.GeneratedCodeAttribute",
+                                                       new CodeAttributeArgument(new CodePrimitiveExpression(CrmSvcUtilsName)),
+                                                       new CodeAttributeArgument(new CodePrimitiveExpression(CrmSvcUtilsVersion))));
+            foreach (var value in values)
+            {
+                CodeMemberField codeMemberField = new CodeMemberField(string.Empty, value.Value);
+                codeMemberField.InitExpression = new CodePrimitiveExpression(value.Key);
+
+                codeMemberField.Comments.Add(new CodeCommentStatement("<summary>", docComment: true));
+                codeMemberField.Comments.Add(new CodeCommentStatement(System.Security.SecurityElement.Escape(value.Description), docComment: true));
+                codeMemberField.Comments.Add(new CodeCommentStatement("</summary>", docComment: true));
+
+                optionSetEnum.Members.Add(codeMemberField);
+            }
+            return optionSetEnum;
+        }
+
+        private CodeTypeMember GenerateEnumTwoOptions(BooleanAttributeMetadata booleanAttribute)
+        {
+            return GenerateEnumOptions(booleanAttribute.SchemaName, EnumItem.ToUniqueValues(booleanAttribute.OptionSet));
+        }
+
+        private CodeTypeMember GenerateConstantTwoOptions(BooleanAttributeMetadata booleanAttribute)
+        {
+            CodeTypeDeclaration booleanOptionSet = new CodeTypeDeclaration(booleanAttribute.SchemaName);
+
+            booleanOptionSet.IsClass = true;
+            booleanOptionSet.Attributes = MemberAttributes.Static | MemberAttributes.Public;
+            var values = EnumItem.ToUniqueValues(booleanAttribute.OptionSet);
+            foreach (var value in values)
+            {
+                CodeMemberField codeMemberField = new CodeMemberField(typeof(bool), value.Value);
+                codeMemberField.InitExpression = new CodePrimitiveExpression(value.Key == 1);
+                codeMemberField.Attributes = MemberAttributes.Const | MemberAttributes.Public;
+                codeMemberField.Comments.Add(new CodeCommentStatement("<summary>", docComment: true));
+                codeMemberField.Comments.Add(new CodeCommentStatement(System.Security.SecurityElement.Escape(value.Description), docComment: true));
+                codeMemberField.Comments.Add(new CodeCommentStatement("</summary>", docComment: true));
+                booleanOptionSet.Members.Add(codeMemberField);
+            }
+            return booleanOptionSet;
+        }
+
+        private void RemoveClass(string baseType)
+        {
+            foreach (CodeNamespace @namespace in codeUnit.Namespaces)
+            {
+                foreach (CodeTypeDeclaration type in @namespace.Types)
+                {
+                    if ($"{@namespace.Name}.{type.Name}" == baseType)
+                    {
+                        @namespace.Types.Remove(type);
+                        return;
+                    }
+                }
+            }
+        }
+
+        private string GetEntityLogicalName(CodeTypeDeclaration type)
+        {
+            foreach (CodeAttributeDeclaration attribute in type.CustomAttributes)
+            {
+                if (attribute.Name == Constants.EntityLogicalNameAttributeType)
+                {
+                    if (attribute.Arguments[0].Value is CodePrimitiveExpression value)
+                    {
+                        return (string)value.Value;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private string GetAttributeLogicalName(CodeTypeMember member)
+        {
+            foreach (CodeAttributeDeclaration attribute in member.CustomAttributes)
+            {
+                if (attribute.Name == Constants.AttributeLogicalNameAttributeType)
+                {
+                    if (attribute.Arguments[0].Value is CodePrimitiveExpression value)
+                    {
+                        return (string)value.Value;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/AlbanianXrm.EarlyBound/AlbanianXrm.EarlyBound.csproj
+++ b/AlbanianXrm.EarlyBound/AlbanianXrm.EarlyBound.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Factories\MyPluginFactory.cs" />
     <Compile Include="Helpers\FilePathEditor.cs" />
     <Compile Include="Helpers\LanguageEnum.cs" />
+    <Compile Include="Helpers\TwoOptionsEnum.cs" />
     <Compile Include="Helpers\YesNoConverter.cs" />
     <Compile Include="Interfaces\IMyPluginFactory.cs" />
     <Compile Include="Logic\AttributeMetadataHandler.cs" />

--- a/AlbanianXrm.EarlyBound/Helpers/TwoOptionsEnum.cs
+++ b/AlbanianXrm.EarlyBound/Helpers/TwoOptionsEnum.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace AlbanianXrm.EarlyBound.Helpers
+{
+    public enum TwoOptionsEnum : byte
+    {
+        [Description("NO")]
+        NO = 0,
+        [Description("Enumeration")]
+        Enumeration = 1,
+        [Description("Boolean Constants")]
+        Constants = 2
+    }
+}

--- a/AlbanianXrm.EarlyBound/Logic/EntityGeneratorHandler.cs
+++ b/AlbanianXrm.EarlyBound/Logic/EntityGeneratorHandler.cs
@@ -157,6 +157,9 @@ namespace AlbanianXrm.EarlyBound.Logic
                     if (allRelationships.Any()) process.StartInfo.EnvironmentVariables.Add(Constants.ENVIRONMENT_ALL_RELATIONSHIPS, string.Join(",", allRelationships));
                     if (options.CurrentOrganizationOptions.RemovePropertyChanged) process.StartInfo.EnvironmentVariables.Add(Constants.ENVIRONMENT_REMOVEPROPERTYCHANGED, "YES");
                     if (options.CacheMetadata) process.StartInfo.EnvironmentVariables.Add(Constants.ENVIRONMENT_CACHEMEATADATA, "YES");
+                    if (options.CurrentOrganizationOptions.OptionSetEnums) process.StartInfo.EnvironmentVariables.Add(Constants.ENVIRONMENT_OPTIONSETENUMS, "YES");
+                    if (options.CurrentOrganizationOptions.OptionSetEnumProperties) process.StartInfo.EnvironmentVariables.Add(Constants.ENVIRONMENT_OPTIONSETENUMPROPERTIES, "YES");
+                    process.StartInfo.EnvironmentVariables.Add(Constants.ENVIRONMENT_TWOOPTIONS, ((int)options.CurrentOrganizationOptions.TwoOptions).ToString());
 #if DEBUG
                     if (options.LaunchDebugger) process.StartInfo.EnvironmentVariables.Add(Constants.ENVIRONMENT_ATTACHDEBUGGER, "YES");
 #endif

--- a/AlbanianXrm.EarlyBound/OrganizationOptions.cs
+++ b/AlbanianXrm.EarlyBound/OrganizationOptions.cs
@@ -58,6 +58,27 @@ namespace AlbanianXrm.EarlyBound
         [TypeConverter(typeof(YesNoConverter))]
         public bool RemovePropertyChanged { get; set; }
 
+        [Category("OptionSet Enums")]
+        [DisplayName("Generate Enums")]
+        [Description("Generate OptionSet Enums.")]
+        [DefaultValue(false)]
+        [TypeConverter(typeof(YesNoConverter))]
+        public bool OptionSetEnums { get; set; }
+
+        [Category("OptionSet Enums")]
+        [DisplayName("Generate TwoOptions")]
+        [Description("Generate Enumerations or Constants for TwoOptions attribute.")]          
+        [DefaultValue(TwoOptionsEnum.NO)]
+        [TypeConverter(typeof(DescriptionEnumConverter))]
+        public TwoOptionsEnum TwoOptions { get; set; }
+
+        [Category("OptionSet Enums")]
+        [DisplayName("Enum Properties")]
+        [Description("Generate Enum Properties")]
+        [DefaultValue(false)]
+        [TypeConverter(typeof(YesNoConverter))]
+        public bool OptionSetEnumProperties { get; set; }
+
         public override string ToString()
         {
             return Key;


### PR DESCRIPTION
Added the ability to generate enumerations for OptionSet and TwoOptions. Alternatively static classes with boolean constants can be generated for TwoOptions.

Tasks:
- [x] Remove StateCode if not actually selected
- [x] Generate Enumerations for OptionSet
- [x] Generate Enumerations for TwoOptions
- [x] Generate Static Classes with Constants for TwoOptions
- [x] Fix StateCode Enum Property
- [x] Generate Option Set Enum Properties